### PR TITLE
Proposed macro ?=

### DIFF
--- a/src/main/clojure/clojure/core/match.clj
+++ b/src/main/clojure/clojure/core/match.clj
@@ -1998,3 +1998,6 @@ col with the first column and compile the result"
     `(let ~bindings
        (match [~@bindvars#]
          ~@body))))
+
+(defmacro ?= [a & body]
+  `(match [~a] [~@body] true :else false))


### PR DESCRIPTION
A subset of pattern matching is really useful when performing non trivial boolean checks, especially on nested maps. This macro makes that use case easy and is something I've been using on my own projects. I just wanted to put it forward for consideration in case anybody else finds it useful, I'm also open to an explanation of why it's a bad idea :) 

E.g.

```
(when (or (= (:action x) :up) (= (:action x) :down)) 
  :foo)
```

becomes

```
(when (?= x {:action (:or :up :down)}) 
  :foo)
```

(as opposed to `(match [x] [{:action (:or :up :down)}] :foo :else nil)`)

Obviously more deeply nested maps where matching comes into its own offer even more advantages.

Thanks, 
Adam
