### PR TITLE
macroexpand patterns before emitting

### DIFF
--- a/src/main/clojure/clojure/core/match.clj
+++ b/src/main/clojure/clojure/core/match.clj
@@ -1765,7 +1765,7 @@ col with the first column and compile the result"
   "Take an unprocessed pattern expression and an action expression and return
    a pattern row of the processed pattern expression plus the action epxression."
   [pat action]
-  (let [ps (map emit-pattern (group-keywords pat))]
+  (let [ps (map (comp emit-pattern macroexpand) (group-keywords pat))]
     (pattern-row ps action)))
 
 (defn wildcards-and-duplicates


### PR DESCRIPTION
This seems like it could be a handy way to create custom binding forms for matching.

eg:

``` clojure
(defrecord RegularClue [round category-idx question-idx])
(defrecord FinalClue   [round])

(defmacro single-jeopardy [c-idx q-idx]
  {:round :single-jeopardy
   :category-idx c-idx
   :question-idx q-idx})
(defmacro double-jeopardy [c-idx q-idx]
  {:round :double-jeopardy
   :category-idx c-idx
   :question-idx q-idx})
(defmacro final-jeopardy []
  {:round :final-jeopardy})

;eg:
(match [(regular-clue)]
  [(single-jeopardy x y)] [:sing x y]
  [(double-jeopardy cat q)] [:dub cat q]
  [(final-jeopardy)] :final-jeopardy)

; or a :keys like destructuring
(defmacro rec-keys [klass & keys]
  (list (into {} (map (fn [k] [(keyword k) k]) keys))
   :guard `#(instance? ~klass %)))

(match [(regular-clue)]
  [(rec-keys RegularClue category-idx)] category-idx
  [(rec-keys FinalClue)] :final-jeopardy)
```
