### PR TITLE
regex: only attempt to match string values.

### DIFF
--- a/src/main/clojure/clojure/core/match/regex.clj
+++ b/src/main/clojure/clojure/core/match/regex.clj
@@ -30,7 +30,9 @@
 
 (defmethod to-source ::m/regex
   [pat ocr]
-  `(re-matches ~(:regex pat) ~ocr))
+  `(let [ocr# ~ocr]
+     (when (string? ocr#)
+       (re-matches ~(:regex pat) ocr#))))
 
 ;; `java.util.regex.Pattern` doesn't override `equals`, so we reinvent it here.
 ;;

--- a/src/test/clojure/clojure/core/match/test/regex.clj
+++ b/src/test/clojure/clojure/core/match/test/regex.clj
@@ -8,3 +8,9 @@
                        [#"asdf"] 1
                        :else 2)
                 1)))
+
+(deftest dont-attempt-to-match-non-string
+         (is (= (match [:not-a-string]
+                       [#"qwerty"] :yes
+                       :else :no)
+                :no)))


### PR DESCRIPTION
Before this fix, matching a regex pattern against a non-string value would crash like so:

```
java.lang.ClassCastException: clojure.lang.Keyword cannot be cast to java.lang.CharSequence
 at clojure.core$re_matcher.invoke (core.clj:4460)
    clojure.core$re_matches.invoke (core.clj:4497)
...
```

Now that I am done with the fix, I'll go and joust JIRA windmills.