### PR TITLE
Update clj, cljs, and remove nrepl dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,12 +6,11 @@
   :test-paths ["src/test/clojure"]
   :source-paths ["src/main/clojure"]
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.analyzer.jvm "0.6.5"]
-                 [org.clojure/clojurescript "0.0-2496" :scope "provided"]]
+                 [org.clojure/clojurescript "1.9.293" :scope "provided"]]
 
-  :plugins [[lein-cljsbuild "1.0.4-SNAPSHOT"]
-            [cider/cider-nrepl "0.8.1"]]
+  :plugins [[lein-cljsbuild "1.1.4"]]
 
   :cljsbuild
   {:builds


### PR DESCRIPTION
Updated clojure version to 1.8 (1.6 is below CIDER support)

Updated cljs version from really really old to current. I have almost no experience with cljs but this seems like a good thing to do.

Updated lein-cljsbuild to current

Cider-nrepl version 0.8 was way out of date and CIDER loads it itself now. It should not be explicitly stated any longer.